### PR TITLE
fix: Correct navigation links in HTML files

### DIFF
--- a/chardham.html
+++ b/chardham.html
@@ -30,10 +30,10 @@
           </div>
           <div class="flex flex-1 justify-end gap-8">
             <div class="flex items-center gap-9">
-              <a class="text-[#181411] text-sm font-medium leading-normal" href="#">Home</a>
-              <a class="text-[#181411] text-sm font-medium leading-normal" href="#">Packages</a>
-              <a class="text-[#181411] text-sm font-medium leading-normal" href="#">About Us</a>
-              <a class="text-[#181411] text-sm font-medium leading-normal" href="#">Contact</a>
+              <a class="text-[#181411] text-sm font-medium leading-normal" href="index.html">Home</a>
+              <a class="text-[#181411] text-sm font-medium leading-normal" href="package.html">Packages</a>
+              <a class="text-[#181411] text-sm font-medium leading-normal" href="index.html">About Us</a>
+              <a class="text-[#181411] text-sm font-medium leading-normal" href="contact-us.html">Contact</a>
             </div>
             <button
               class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-lg h-10 px-4 bg-[#eb6d13] text-white text-sm font-bold leading-normal tracking-[0.015em]"

--- a/index.html
+++ b/index.html
@@ -30,10 +30,10 @@
           </div>
           <div class="flex flex-1 justify-end gap-8">
             <div class="flex items-center gap-9">
-              <a class="text-[#181411] text-sm font-medium leading-normal" href="#">Home</a>
-              <a class="text-[#181411] text-sm font-medium leading-normal" href="#">Packages</a>
-              <a class="text-[#181411] text-sm font-medium leading-normal" href="#">About Us</a>
-              <a class="text-[#181411] text-sm font-medium leading-normal" href="#">Contact</a>
+              <a class="text-[#181411] text-sm font-medium leading-normal" href="index.html">Home</a>
+              <a class="text-[#181411] text-sm font-medium leading-normal" href="package.html">Packages</a>
+              <a class="text-[#181411] text-sm font-medium leading-normal" href="index.html">About Us</a>
+              <a class="text-[#181411] text-sm font-medium leading-normal" href="contact-us.html">Contact</a>
             </div>
             <button
               class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-lg h-10 px-4 bg-[#eb6d13] text-white text-sm font-bold leading-normal tracking-[0.015em]"
@@ -141,10 +141,10 @@
           <div class="flex max-w-[960px] flex-1 flex-col">
             <footer class="flex flex-col gap-6 px-5 py-10 text-center @container">
               <div class="flex flex-wrap items-center justify-center gap-6 @[480px]:flex-row @[480px]:justify-around">
-                <a class="text-[#897261] text-base font-normal leading-normal min-w-40" href="#">Home</a>
-                <a class="text-[#897261] text-base font-normal leading-normal min-w-40" href="#">Packages</a>
-                <a class="text-[#897261] text-base font-normal leading-normal min-w-40" href="#">About Us</a>
-                <a class="text-[#897261] text-base font-normal leading-normal min-w-40" href="#">Contact</a>
+                <a class="text-[#897261] text-base font-normal leading-normal min-w-40" href="index.html">Home</a>
+                <a class="text-[#897261] text-base font-normal leading-normal min-w-40" href="package.html">Packages</a>
+                <a class="text-[#897261] text-base font-normal leading-normal min-w-40" href="index.html">About Us</a>
+                <a class="text-[#897261] text-base font-normal leading-normal min-w-40" href="contact-us.html">Contact</a>
               </div>
               <p class="text-[#897261] text-base font-normal leading-normal">© 2024 MS Travels. All rights reserved.</p>
             </footer>

--- a/package.html
+++ b/package.html
@@ -30,10 +30,10 @@
           </div>
           <div class="flex flex-1 justify-end gap-8">
             <div class="flex items-center gap-9">
-              <a class="text-[#181411] text-sm font-medium leading-normal" href="#">Home</a>
-              <a class="text-[#181411] text-sm font-medium leading-normal" href="#">Packages</a>
-              <a class="text-[#181411] text-sm font-medium leading-normal" href="#">About Us</a>
-              <a class="text-[#181411] text-sm font-medium leading-normal" href="#">Contact</a>
+              <a class="text-[#181411] text-sm font-medium leading-normal" href="index.html">Home</a>
+              <a class="text-[#181411] text-sm font-medium leading-normal" href="package.html">Packages</a>
+              <a class="text-[#181411] text-sm font-medium leading-normal" href="index.html">About Us</a>
+              <a class="text-[#181411] text-sm font-medium leading-normal" href="contact-us.html">Contact</a>
             </div>
             <button
               class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-lg h-10 px-4 bg-[#eb6d13] text-white text-sm font-bold leading-normal tracking-[0.015em]"


### PR DESCRIPTION
- Updated placeholder href="#" attributes in index.html, chardham.html, and package.html to point to the correct local HTML files (e.g., index.html, package.html, contact-us.html).
- Ensured links use relative paths for compatibility with GitHub Pages.

This change allows you to navigate between the main pages of the website.